### PR TITLE
adds common folders for particle tools

### DIFF
--- a/src/cmd/commands.js
+++ b/src/cmd/commands.js
@@ -14,3 +14,4 @@ export * from './library_publish';
 export * from './library_search';
 export * from './project_init';
 export * from './project_properties';
+export * from './projects';

--- a/src/cmd/projects.js
+++ b/src/cmd/projects.js
@@ -8,6 +8,7 @@ const particle = 'particle';
 const libraries = 'libraries';
 const projects = 'projects';
 const community = 'community';
+const mine = 'mine';
 
 const fsMkdir = promisify(fs.mkdir);
 const fsExists = promisify(fs.exists);
@@ -50,19 +51,27 @@ export class Projects {
 	}
 
 	librariesFolder() {
-		return path.join(this.myLibrariesFolder(), community);
-	}
-
-	myLibrariesFolder() {
 		return path.join(this.particleFolder(), libraries);
 	}
 
+	communityLibrariesFolder() {
+		return path.join(this.librariesFolder(), community);
+	}
+
+	myLibrariesFolder() {
+		return path.join(this.librariesFolder(), mine);
+	}
+
 	projectsFolder() {
-		return path.join(this.myProjectsFolder(), community);
+		return path.join(this.particleFolder(), projects);
+	}
+
+	communityProjectsFolder() {
+		return path.join(this.projectsFolder(), community);
 	}
 
 	myProjectsFolder() {
-		return path.join(this.particleFolder(), projects);
+		return path.join(this.projectsFolder(), mine);
 	}
 
 	ensureDirectoryExists(directory) {

--- a/src/cmd/projects.js
+++ b/src/cmd/projects.js
@@ -1,0 +1,72 @@
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import promisify from 'es6-promisify';
+
+const particle = 'particle';
+const libraries = 'libraries';
+const projects = 'projects';
+const community = 'community';
+
+const fsMkdir = promisify(fs.mkdir);
+const fsExists = promisify(fs.exists);
+
+function mkdir(name) {
+	return fsMkdir(name)
+		.then(() => true)
+		.catch(error => {
+			if (error.code==='EEXIST')
+				return false;
+			throw error;
+		});
+}
+
+function mkdirp(name) {
+	return fsExists(name).then(exists => {
+		if (!exists) {
+			const parent = path.dirname(name);
+			const makeit = mkdir(name);
+			let promise = makeit;
+			if (parent && parent!=='/') {
+				promise = mkdirp(parent).then(() => makeit);
+			}
+			return promise;
+		}
+	});
+}
+
+
+export class Projects {
+
+	userHomeFolder() {
+		return os.homedir();
+	}
+
+	// todo - documnents folder?
+
+	particleFolder() {
+		return path.join(this.userHomeFolder(), particle);
+	}
+
+	librariesFolder() {
+		return path.join(this.myLibrariesFolder(), community);
+	}
+
+	myLibrariesFolder() {
+		return path.join(this.particleFolder(), libraries);
+	}
+
+	projectsFolder() {
+		return path.join(this.myProjectsFolder(), community);
+	}
+
+	myProjectsFolder() {
+		return path.join(this.particleFolder(), projects);
+	}
+
+	ensureDirectoryExists(directory) {
+		return mkdirp(directory);
+	}
+
+}

--- a/test/cmd/projects_spec.js
+++ b/test/cmd/projects_spec.js
@@ -22,19 +22,19 @@ describe('projects', () => {
 	});
 
 	it('can retrieve my projects common folder', () => {
-		expect(sut.myProjectsFolder()).equals(path.join(home, 'particle', 'projects'));
+		expect(sut.myProjectsFolder()).equals(path.join(home, 'particle', 'projects', 'mine'));
 	});
 
 	it('can retrieve community projects common folder', () => {
-		expect(sut.projectsFolder()).equals(path.join(home, 'particle', 'projects', 'community'));
+		expect(sut.communityProjectsFolder()).equals(path.join(home, 'particle', 'projects', 'community'));
 	});
 
 	it('can retrieve my libraries common folder', () => {
-		expect(sut.myLibrariesFolder()).equals(path.join(home, 'particle', 'libraries'));
+		expect(sut.myLibrariesFolder()).equals(path.join(home, 'particle', 'libraries', 'mine'));
 	});
 
 	it('can retrieve community libraries common folder', () => {
-		expect(sut.librariesFolder()).equals(path.join(home, 'particle', 'libraries', 'community'));
+		expect(sut.communityLibrariesFolder()).equals(path.join(home, 'particle', 'libraries', 'community'));
 	});
 
 

--- a/test/cmd/projects_spec.js
+++ b/test/cmd/projects_spec.js
@@ -1,0 +1,41 @@
+import {expect, sinon} from '../test-setup';
+import {Projects} from '../../src/cmd/projects';
+const fs = require('fs');
+const mockfs = require('mock-fs');
+import path from 'path';
+
+describe('projects', () => {
+
+	beforeEach(() => {
+		mockfs({});
+	});
+
+	afterEach(() => {
+		return mockfs.restore();
+	});
+
+	let sut;
+	const home = '/home';
+	beforeEach(() => {
+		sut = new Projects();
+		sut.userHomeFolder = sinon.stub().returns(home);
+	});
+
+	it('can retrieve my projects common folder', () => {
+		expect(sut.myProjectsFolder()).equals(path.join(home, 'particle', 'projects'));
+	});
+
+	it('can retrieve community projects common folder', () => {
+		expect(sut.projectsFolder()).equals(path.join(home, 'particle', 'projects', 'community'));
+	});
+
+	it('can retrieve my libraries common folder', () => {
+		expect(sut.myLibrariesFolder()).equals(path.join(home, 'particle', 'libraries'));
+	});
+
+	it('can retrieve community libraries common folder', () => {
+		expect(sut.librariesFolder()).equals(path.join(home, 'particle', 'libraries', 'community'));
+	});
+
+
+});


### PR DESCRIPTION
This is a quick implementation based on the work discussed so far. 

Happy for thoughts on structure, names etc..

- currently all folders are in `Projects`. should it be split into `Projects`, `Libraries` and `Particle` so each region has it's own class? (with Particle defining the shared particle folder, used by the others.)

- are the names ok? should projectsFolder() be communityProjectsFolder(), or importedProjectsFolder() etc...  